### PR TITLE
Fix typo in examples/cli.ini

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -263,6 +263,7 @@ Authors
 * [Ville Skyttä](https://github.com/scop)
 * [Vinney Cavallo](https://github.com/vcavallo)
 * [Vladimir Rutsky](https://github.com/rutsky)
+* [Vitaly Rybnikov](https://github.com/Frodox)
 * [Wang Yu](https://github.com/wyhitcs)
 * [Ward Vandewege](https://github.com/cure)
 * [Whyfoo](https://github.com/whyfoo)

--- a/certbot/examples/cli.ini
+++ b/certbot/examples/cli.ini
@@ -23,4 +23,4 @@ rsa-key-size = 4096
 # Uncomment to use the webroot authenticator. Replace webroot-path with the
 # path to the public_html / webroot folder being served by your web server.
 # authenticator = webroot
-# webroot-path = /usr/share/nginx/html
+# webroot_path = /usr/share/nginx/html


### PR DESCRIPTION
According to [code](https://github.com/certbot/certbot/blob/master/certbot/certbot/_internal/renewal.py#L115) and logic it is 5-years old typo here :thinking:

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Include your name in `AUTHORS.md` if you like.
